### PR TITLE
Fix missing favicon

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {
-        "build": "tsc",
+        "build": "tsc && cp src/index.html dist/index.html && cp src/styles.css dist/styles.css",
         "start": "http-server dist -p ${PORT:-9992}"
     },
     "dependencies": {


### PR DESCRIPTION
## Summary
- add a small favicon so the web server no longer logs 404s
- update the client build to copy static assets
- remove the favicon.ico as GitHub does not accept binary

## Testing
- `npm run build` in `client`
- `npm run build` in `server`
- `npm start` *(fails: Cannot find module 'express')*